### PR TITLE
Add missing r.js to bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "tests"
   ],
   "dependencies": {
+    "r.js": ">=2.1.16",
     "react": ">=0.11.2",
     "requirejs-text": ">=2.0.12"
   }

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,9 @@ require(['jsx!app'], function(App){
 ```
 
 ### Building
-
-Call with `$ node bower_components/r.js/dist/r.js -o build.js`
+```sh
+$ node bower_components/r.js/dist/r.js -o build.js
+```
 
 In your [r.js](https://github.com/jrburke/r.js/) `build.js` config:
 


### PR DESCRIPTION
Without [`r.js`](https://github.com/jrburke/r.js/) in `bower.json` the following command from `readme.md` will fail:
```sh
$ node bower_components/r.js/dist/r.js -o build.js
```


