### PR TITLE
Added support for Babel

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![NPM version](https://badge.fury.io/js/requirejs-react-jsx.svg)](http://badge.fury.io/js/requirejs-react-jsx)
 [![Dependency Status](http://img.shields.io/gemnasium/podio/requirejs-react-jsx.svg?style=flat-square)](https://gemnasium.com/podio/requirejs-react-jsx)
 
-A RequireJS plugin for compiling React JSX files. Will use [react-tools](https://www.npmjs.org/package/react-tools) when compiling using `r.js`, and will use `JSXTransformer` when running in the browser in development. This allows us to support multiple bundles in `r.js` and exclude the `JSXTransformer` from all of them since we're requiring it dynamically and not explicitly. This also means that we can get `1:1` Source Maps in both development and production.
+A RequireJS plugin for compiling React JSX files. Will use [react-tools](https://www.npmjs.org/package/react-tools) when compiling using `r.js`, and will use `JSXTransformer` or Babel when running in the browser in development. This allows us to support multiple bundles in `r.js` and exclude the `JSXTransformer` from all of them since we're requiring it dynamically and not explicitly. This also means that we can get `1:1` Source Maps in both development and production.
 
 # Example
 
@@ -92,6 +92,18 @@ require(['jsx!app'], function(App){
   app.init();
 
 });
+```
+
+Can also be configured with Babel:
+```javascript
+config: {
+  jsx: {
+    transformer: "babel",
+    babelOptions: {
+      sourceMaps: 'inline'
+    }
+  }
+}
 ```
 
 ### Building


### PR DESCRIPTION
We need this in Podio to keep Require.js running while moving to React 0.14, due to the deprecation of JSXTransform.