### PR TITLE
fix source map in Chrome

### DIFF
--- a/jsx.js
+++ b/jsx.js
@@ -53,6 +53,7 @@ define(function () {
       var onLoad = function(content, babel) {
 
         try {
+          options.filename = name;
           var transform = babel.transform(ensureJSXPragma(content, config), options);
 
           content = transform.code;


### PR DESCRIPTION
I'm using the latest combination:
react: 0.14.3
requirejs: 2.1.22
requirejs-react-jsx: 0.15.0
requirejs-text: 2.0.14
requirejs-babel: 0.0.8 (babel is 5.8.22)

And source map doesn't work in Chrome but works in Safari instead. I switched to official babel 6 code and found that its options, filename, also serves as source map filename, which is not mentioned in the official guide. So I added a line to fix the issue.

Please have a check. And good works, btw.